### PR TITLE
Fix Unauthorized API Access Issues

### DIFF
--- a/src/pages/teacher/StudyMaterials.tsx
+++ b/src/pages/teacher/StudyMaterials.tsx
@@ -49,6 +49,7 @@ import {
 } from '@mui/icons-material';
 import axios from 'axios';
 import { useAuth } from '../../context/AuthContext';
+import { coursesAPI } from '../../services/api';
 import TeacherLayout from '../../components/layout/TeacherLayout';
 
 interface Course {
@@ -179,11 +180,8 @@ const StudyMaterials: React.FC = () => {
   const fetchCourses = async () => {
     setLoading(true);
     try {
-      const token = localStorage.getItem('token');
-      const response = await axios.get('http://localhost:8000/courses/my-courses', {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      setCourses(response.data);
+      const data = await coursesAPI.getLecturerCourses();
+      setCourses(data);
       setError(null);
     } catch (err) {
       console.error('Error fetching courses:', err);


### PR DESCRIPTION


## Problem
The application was experiencing 401 Unauthorized errors when trying to access
protected endpoints such as `/courses/my-courses`. This happened because some
API calls were made directly using axios instead of using the configured API
service that properly handles authentication tokens.

## Solution
- Modified direct axios calls to use the coursesAPI utility service
- This ensures the authentication token is consistently included in all API requests
- Fixed the specifically failing endpoint in StudyMaterials.tsx

## Changes
- Updated `lms-frontend/src/pages/teacher/StudyMaterials.tsx` to use coursesAPI.getLecturerCourses()
- Removed manually constructed axios request with direct token handling
- Added the proper API service import

## Testing
- Verified the lecturer can now access their courses without 401 errors
- Confirmed the token is being properly passed in requests
- Ensured all other functionality works as expected

## Additional Notes
This change follows the established pattern of using API service modules for
all backend communication, maintaining consistency throughout the codebase
and preventing similar authentication issues in the future.